### PR TITLE
docs: use @main in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ See [`USAGE.md`](./USAGE.md) for:
 - PAT vs `GITHUB_TOKEN`, merge modes, and troubleshooting
 
 ## Model compatibility
+
+## Model selection
+- Default model: `gpt-5-nano` (fast and cost‑effective).
+- Override via workflow input: `with: model: gpt-4o-mini` (or any accessible model for your key).
+- The Action passes the model explicitly to the CLI (`--model <id>` when supported) and also exports `OPENAI_MODEL` and `CODEX_MODEL` for env‑based clients.
+- If you see `401 Unauthorized`, your API key likely lacks access to the selected model.
 - OpenAI (Codex / GPT‑5): first‑class
 - Qwen / Qwen‑Code: configurable
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -238,3 +238,15 @@ with:
 ## Notes
 - Smart Doc writes only under `docs/` (English) and optionally appends `SMART_TIMELINE.md`.
 - It never pushes directly to protected branches; it opens a PR instead.
+
+## Choosing a model
+- Default: `gpt-5-nano` (cheap/fast). Override with the `model` input.
+- The Action passes `--model` to the CLI when supported and exports `OPENAI_MODEL` and `CODEX_MODEL`.
+- Errors `401 Unauthorized` usually mean your API key lacks access to the chosen model.
+
+Example override:
+```yaml
+with:
+  smart_doc_api_token: ${{ secrets.SMART_DOC_API_TOKEN }}
+  model: gpt-4o-mini
+```

--- a/docs/modules/doc-updater.md
+++ b/docs/modules/doc-updater.md
@@ -1,26 +1,3 @@
-# Doc Updater
-
-## Purpose
-Runs the Codex CLI with the built prompt to update documentation under `docs/`, and signals whether any changes were made.
-
-## Key Files
-- `scripts/doc-updater.sh`
-
-## Behavior (as of this commit)
-- Strict Bash mode (`set -euo pipefail`).
-- Inputs:
-  - `INPUT_DOCS_FOLDER` (default: `docs`)
-  - `PROMPT_FILE` (default: `tmp/prompt.md`)
-  - `INPUT_MODEL` (default: `gpt-5-nano`)
-- Emits logs with a consistent prefix for traceability.
-
 ## Notable Notes
-- Contains a minor note about a future `--dry-run` at the LLM level (today handled downstream), indicating planned improvements without behavior change.
-
-## Outputs
-- Updates files under `docs/` when warranted by the prompt/policy.
-- Signals changes via `tmp/have_changes.flag` (created downstream by the orchestrator).
-
-## TODO
-- Add first-class `--dry-run` support when the underlying CLI exposes it.
-
+- Use `INPUT_MODEL` to control cost/perf; `gpt-5-nano` is the default.
+- CLI `--dry-run` is a future option if/when exposed; today, previews happen via PR mode.

--- a/docs/modules/doc-updater.md
+++ b/docs/modules/doc-updater.md
@@ -1,3 +1,27 @@
+# Doc Updater
+
+## Purpose
+Runs the Codex CLI with the built prompt to update documentation under `docs/`, and signals whether any changes were made.
+
+## Key Files
+- `scripts/doc-updater.sh`
+
+## Behavior
+- Strict Bash mode (`set -euo pipefail`).
+- Inputs:
+  - `INPUT_DOCS_FOLDER` (default: `docs`)
+  - `PROMPT_FILE` (default: `tmp/prompt.md`)
+  - `INPUT_MODEL` (default: `gpt-5-nano`)
+- Model selection:
+  - Exports `OPENAI_MODEL` and `CODEX_MODEL` with the resolved model id.
+  - Passes `--model <id>` to the CLI (`code`, `codex`, or `npx @openai/codex`) when supported.
+  - Falls back to env‑only if the CLI doesn’t support `--model`.
+- Writes concise logs and a change flag at `tmp/have_changes.flag`.
+
+## Outputs
+- Updates files under `docs/` when warranted by the prompt/policy.
+- Signals changes via `tmp/have_changes.flag` (`yes`/`no`).
+
 ## Notable Notes
 - Use `INPUT_MODEL` to control cost/perf; `gpt-5-nano` is the default.
 - CLI `--dry-run` is a future option if/when exposed; today, previews happen via PR mode.


### PR DESCRIPTION
Update README/USAGE examples to point to `galiprandi/smart-doc@main` until a new tagged release includes recent fixes.